### PR TITLE
Avoid use of global Chart inside function

### DIFF
--- a/src/chartjs-plugin-labels.js
+++ b/src/chartjs-plugin-labels.js
@@ -14,7 +14,8 @@
     console.error('Cannot find Chart object.');
     return;
   }
-  const helpers = Chart.helpers
+
+  const helpers = Chart.helpers;
 
   if (typeof Object.assign !== 'function') {
     Object.assign = function (target) {


### PR DESCRIPTION
This is to support environments which may not have access to the global Chart object anymore after the initial setup (chartjs-node-canvas).