### PR TITLE
 Allow for unlabeled charts along side labeled charts

### DIFF
--- a/src/chartjs-plugin-labels.js
+++ b/src/chartjs-plugin-labels.js
@@ -432,9 +432,9 @@
 
   function isPluginsLabelsDefined(options) {
     const chartConfig = options._context.chart.config._config;
-    if (!chartConfig.options || !chartConfig.options.plugins)
-      return false;
-    return !!chartConfig.options.plugins.labels;
+    if (chartConfig.options && chartConfig.options.plugins)
+      return !!chartConfig.options.plugins.labels;
+    return false;
   }
   // eslint-disable-next-line no-undef
   Chart.register({

--- a/src/chartjs-plugin-labels.js
+++ b/src/chartjs-plugin-labels.js
@@ -430,14 +430,14 @@
     return image;
   };
 
-  function isDefined(options){
+  function isPluginsLabelsDefined(options) {
     return !!options._context.chart.config._config.options.plugins.labels;
   }
   // eslint-disable-next-line no-undef
   Chart.register({
     id: 'labels',
     beforeDatasetsUpdate: function (chart, args, options) {
-      if (!SUPPORTED_TYPES[chart.config.type] || !isDefined(options)) {
+      if (!SUPPORTED_TYPES[chart.config.type] || !isPluginsLabelsDefined(options)) {
         return;
       }
       if (!options.length) {
@@ -467,7 +467,7 @@
       }
     },
     afterDatasetUpdate: function (chart, args, options) {
-      if (!SUPPORTED_TYPES[chart.config.type] || !isDefined(options)) {
+      if (!SUPPORTED_TYPES[chart.config.type] || !isPluginsLabelsDefined(options)) {
         return;
       }
       chart._labels.forEach(function (label) {
@@ -475,7 +475,7 @@
       });
     },
     beforeDraw: function (chart, args, options) {
-      if (!SUPPORTED_TYPES[chart.config.type] || !isDefined(options)) {
+      if (!SUPPORTED_TYPES[chart.config.type] || !isPluginsLabelsDefined(options)) {
         return;
       }
       chart._labels.forEach(function (label) {
@@ -483,7 +483,7 @@
       });
     },
     afterDatasetsDraw: function (chart, args, options) {
-      if (!SUPPORTED_TYPES[chart.config.type] || !isDefined(options)) {
+      if (!SUPPORTED_TYPES[chart.config.type] || !isPluginsLabelsDefined(options)) {
         return;
       }
       chart._labels.forEach(function (label) {

--- a/src/chartjs-plugin-labels.js
+++ b/src/chartjs-plugin-labels.js
@@ -2,7 +2,7 @@
  * [chartjs-plugin-labels]{@link https://github.com/DavideViolante/chartjs-plugin-labels}
  *
  * @version 3.1.0
- * @author Chen, Yi-Cyuan [emn178@gmail.com], Davide Violante
+ * @author Chen, Yi-Cyuan [emn178@gmail.com], Davide Violante, Yousef Altaher
  * @copyright Chen, Yi-Cyuan 2017-2018
  * @license MIT
  */
@@ -430,11 +430,14 @@
     return image;
   };
 
+  function isDefined(options){
+    return !!options._context.chart.config._config.options.plugins.labels;
+  }
   // eslint-disable-next-line no-undef
   Chart.register({
     id: 'labels',
     beforeDatasetsUpdate: function (chart, args, options) {
-      if (!SUPPORTED_TYPES[chart.config.type]) {
+      if (!SUPPORTED_TYPES[chart.config.type] || !isDefined(options)) {
         return;
       }
       if (!options.length) {
@@ -463,24 +466,24 @@
         chart.chartArea.bottom -= maxPadding;
       }
     },
-    afterDatasetUpdate: function (chart, args) {
-      if (!SUPPORTED_TYPES[chart.config.type]) {
+    afterDatasetUpdate: function (chart, args, options) {
+      if (!SUPPORTED_TYPES[chart.config.type] || !isDefined(options)) {
         return;
       }
       chart._labels.forEach(function (label) {
         label.args[args.index] = args;
       });
     },
-    beforeDraw: function (chart) {
-      if (!SUPPORTED_TYPES[chart.config.type]) {
+    beforeDraw: function (chart, args, options) {
+      if (!SUPPORTED_TYPES[chart.config.type] || !isDefined(options)) {
         return;
       }
       chart._labels.forEach(function (label) {
         label.barTotalPercentage = {};
       });
     },
-    afterDatasetsDraw: function (chart) {
-      if (!SUPPORTED_TYPES[chart.config.type]) {
+    afterDatasetsDraw: function (chart, args, options) {
+      if (!SUPPORTED_TYPES[chart.config.type] || !isDefined(options)) {
         return;
       }
       chart._labels.forEach(function (label) {

--- a/src/chartjs-plugin-labels.js
+++ b/src/chartjs-plugin-labels.js
@@ -431,7 +431,10 @@
   };
 
   function isPluginsLabelsDefined(options) {
-    return !!options._context.chart.config._config.options.plugins.labels;
+    const chartConfig = options._context.chart.config._config;
+    if (!chartConfig.options || !chartConfig.options.plugins)
+      return false;
+    return !!chartConfig.options.plugins.labels;
   }
   // eslint-disable-next-line no-undef
   Chart.register({


### PR DESCRIPTION
 Allow for unlabeled charts along side labeled charts by assuming that  if the label tag is not available on the options for the graph, the labels will not be present, in contrary to the current one, which always attach labels.

References Issue:  #12